### PR TITLE
[NOTICKET] Add support for `since_commit` input option when generating git diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ This action expects a [.tx/config file](https://developers.transifex.com/docs/us
 
 ## Input Options
 
-- `since_commit`: By default, this action will check for changes against the last commit (`HEAD~1`). If you'd like to push changes for more than the most recent commit, use the `since_commit` action to specify this.
+- `since_commit`: By default, this action will check for changes against the last commit (`HEAD~1`). If you'd like to push changes for more than the most recent commit, use the `since_commit` input option to specify this.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # Push Translations
 
 Pushes translations on merge to master, and notifies Slack of the changes.
+
+## Configuration
+
+This action expects a [.tx/config file](https://developers.transifex.com/docs/using-the-client#adding-resources-to-configuration) configured for your project
+
+## Input Options
+
+- `since_commit`: By default, this action will check for changes against the last commit (`HEAD~1`). If you'd like to push changes for more than the most recent commit, use the `since_commit` action to specify this.

--- a/action.yml
+++ b/action.yml
@@ -1,3 +1,8 @@
+inputs:
+  since_commit:
+    description: 'The base commit to check against for determining if there have been translation file changes (optional)'
+    required: false
+
 name: "Push Translations"
 description: "Push translations to Transifex on changes to source files on master"
 author: "Lightspeed HQ"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@actions/core": "^1.10.0",
     "@slack/webhook": "^5.0.1",
     "flat": "^5.0.0",
     "ini": "^1.3.5",

--- a/src/entrypoint.ts
+++ b/src/entrypoint.ts
@@ -7,6 +7,7 @@ import util from "util";
 import ini from "ini";
 import { exec } from "child_process";
 import { IncomingWebhook } from "@slack/webhook";
+import { getInput } from "@actions/core";
 
 const git = simplegit();
 const execAsync = util.promisify(exec);
@@ -28,6 +29,7 @@ const pushTranslations = async ({ slackWebhookUrl }: Input) => {
   const { main, ...nestedResources } = txConfig;
   const resources: ResourceConfigs = flat(nestedResources, { maxDepth: 1 });
   const resourceNames = Object.keys(resources);
+  const sinceCommit = getInput("since_commit") || "HEAD~1";
 
   let pushed = [];
   for (const resourceName of resourceNames) {
@@ -42,14 +44,17 @@ const pushTranslations = async ({ slackWebhookUrl }: Input) => {
 
       // Determine if the source file has been updated
       const sourceFilename = resources[resourceName].source_file;
-      const diffSummary = await git.diffSummary(["HEAD~1"]);
+      console.log(
+        `Checking for changes to ${sourceFilename} since ${sinceCommit}`
+      );
+      const diffSummary = await git.diffSummary([sinceCommit]);
       const source = diffSummary.files
         .map(({ file }) => file)
         .find((path) => path.includes(sourceFilename));
 
       // Nothing to do if source file has not been changed
       if (!source) {
-        console.log(`Source file unchanged for ${resourceID}`);
+        console.log(`Source file unchanged for ${resourceID} since ${sinceCommit}`);
         continue;
       }
 
@@ -60,7 +65,7 @@ const pushTranslations = async ({ slackWebhookUrl }: Input) => {
       console.log(`Transifex push output:\n${stdout}`);
 
       // // Track changes in resource files for Slack notification
-      const diff = await git.diff(["HEAD~1", "--", sourceFilename]);
+      const diff = await git.diff([sinceCommit, "--", sourceFilename]);
       const changes = diff
         .split("\n")
         .filter((line) => line.match(/^(\+|\-) /g))

--- a/src/entrypoint.ts
+++ b/src/entrypoint.ts
@@ -29,7 +29,7 @@ const pushTranslations = async ({ slackWebhookUrl }: Input) => {
   const { main, ...nestedResources } = txConfig;
   const resources: ResourceConfigs = flat(nestedResources, { maxDepth: 1 });
   const resourceNames = Object.keys(resources);
-  const sinceCommit = getInput("since_commit") || "HEAD~1";
+  const sinceCommit = getInput("since_commit", { required: false }) || "HEAD~1";
 
   let pushed = [];
   for (const resourceName of resourceNames) {
@@ -54,7 +54,9 @@ const pushTranslations = async ({ slackWebhookUrl }: Input) => {
 
       // Nothing to do if source file has not been changed
       if (!source) {
-        console.log(`Source file unchanged for ${resourceID} since ${sinceCommit}`);
+        console.log(
+          `Source file unchanged for ${resourceID} since ${sinceCommit}`
+        );
         continue;
       }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,21 @@
 # yarn lockfile v1
 
 
+"@actions/core@^1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.10.0.tgz#44551c3c71163949a2f06e94d9ca2157a0cfac4f"
+  integrity sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==
+  dependencies:
+    "@actions/http-client" "^2.0.1"
+    uuid "^8.3.2"
+
+"@actions/http-client@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@actions/http-client/-/http-client-2.0.1.tgz#873f4ca98fe32f6839462a6f046332677322f99c"
+  integrity sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==
+  dependencies:
+    tunnel "^0.0.6"
+
 "@slack/types@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@slack/types/-/types-1.1.0.tgz#64465b6c7e2db66498f335934335da81c15812e7"
@@ -99,7 +114,17 @@ simple-git@^1.126.0:
   dependencies:
     debug "^4.0.1"
 
+tunnel@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
+  integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
+
 typescript@^3.6.2:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.2.tgz#105b0f1934119dde543ac8eb71af3a91009efe54"
   integrity sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
By default, this action will check for changes against the last commit (`HEAD~1`) and only push to transifex if there are translation file changes in that commit. This breaks for certain workflows if trying to push translations if the most recent commit is not the one that contains the changes.

To work around this, I've added a `since_commit` input option that will allow specifying an arbitrary commit sha for comparison.
